### PR TITLE
Maintain Cython 0.29.37 for C-extension stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.10-alpine3.22
-RUN apk add --update --no-cache && apk update && apk -U upgrade
-# Combine apk commands for efficiency + latest security patches
+
+# 1. System Dependencies
+# Optimized to include everything needed for C-extensions and security patches
 RUN apk update --no-cache && \
     apk upgrade --no-cache && \
     apk add --no-cache \
@@ -19,23 +20,30 @@ RUN apk update --no-cache && \
         libcrypto3 \
         libexpat \
         libssl3 \
-        musl \
-        musl-dev \
-        musl-utils \
-        openssl-dev \
         zlib \
         zlib-dev
 
+# 2. Upgrade Core Build Tools
+# We install Cython here so it is available to all child images
 RUN pip install --no-cache-dir --upgrade \
     pip>=26.0.1 \
-    "wheel>=0.46.2" \
-    "setuptools>=75.0" \
-    "jaraco.context>=6.1.0" \
-    "urllib3>=2.6.0"
-# Avoid pinning pip/wheel too low unless required for a specific CVE — modern ones are better
-RUN pip install --no-cache-dir \
+    wheel>=0.46.2 \
+    setuptools>=75.0 \
+    Cython==0.29.37 
+
+# 3. Install Foundational Data Science Libraries
+# Use --no-build-isolation to ensure they use the Cython/Setuptools we just installed
+RUN pip install --no-cache-dir --no-build-isolation \
     "pandas>=2.2.0" \
-    cython==0.29.37 \
-    numpy==1.24.2 \
+    "numpy==1.24.2" \
     "confluent-kafka==1.5.0" \
-    pyarrow==20.0.0
+    "pyarrow==20.0.0" \
+    "urllib3>=2.6.0"
+
+# 4. Fix the Pathing for pytest and other binaries
+# This ensures that when you run 'pytest' in Drone, it finds the binary in /usr/local/bin
+ENV PATH="/usr/local/bin:${PATH}"
+ENV PYTHONPATH="/usr/local/lib/python3.10/site-packages"
+
+# Set default workdir
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,31 @@
 FROM python:3.10-alpine3.22
 
 # 1. System Dependencies
-# Optimized to include everything needed for C-extensions and security patches
 RUN apk update --no-cache && \
     apk upgrade --no-cache && \
     apk add --no-cache \
-        cmake \
-        build-base \
-        bash \
-        gcc \
-        g++ \
-        musl-dev \
-        git \
-        libffi-dev \
-        librdkafka-dev \
-        python3-dev \
-        openssl-dev \
-        linux-headers \
-        libcrypto3 \
-        libexpat \
-        libssl3 \
-        zlib \
-        zlib-dev
+        cmake build-base bash gcc g++ musl-dev git \
+        libffi-dev librdkafka-dev python3-dev openssl-dev \
+        linux-headers libcrypto3 libexpat libssl3 zlib zlib-dev
 
-# 2. Upgrade Core Build Tools
-# We install Cython here so it is available to all child images
-RUN pip install --no-cache-dir --upgrade \
-    pip>=26.0.1 \
-    wheel>=0.46.2 \
-    setuptools>=75.0 \
-    Cython==0.29.37 
+# 2. CRITICAL CHANGE: Downgrade Setuptools for NumPy 1.24.2 compatibility
+# NumPy 1.24.x requires setuptools < 60 to find distutils during build
+RUN pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2
+RUN pip install --no-cache-dir "setuptools<60.0" "Cython==0.29.37"
 
-# 3. Install Foundational Data Science Libraries
-# Use --no-build-isolation to ensure they use the Cython/Setuptools we just installed
+# 3. Install NumPy and Data Science tools
+# Now NumPy 1.24.2 will find distutils and compile successfully
 RUN pip install --no-cache-dir --no-build-isolation \
-    "pandas>=2.2.0" \
     "numpy==1.24.2" \
+    "pandas>=2.2.0" \
     "confluent-kafka==1.5.0" \
     "pyarrow==20.0.0" \
     "urllib3>=2.6.0"
 
-# 4. Fix the Pathing for pytest and other binaries
-# This ensures that when you run 'pytest' in Drone, it finds the binary in /usr/local/bin
+# 4. Now upgrade Setuptools back to a secure/modern version for the App
+RUN pip install --no-cache-dir --upgrade "setuptools>=75.0" "jaraco.context>=6.1.0"
+
 ENV PATH="/usr/local/bin:${PATH}"
 ENV PYTHONPATH="/usr/local/lib/python3.10/site-packages"
 
-# Set default workdir
 WORKDIR /app


### PR DESCRIPTION
1. - Downgrade setuptools to <60.0 during the NumPy build phase to restore legacy 'distutils', resolving the 'ModuleNotFoundError: distutils.msvccompiler' error.
3. - Use --no-build-isolation to ensure NumPy uses the compatible build environment.
4. - Re-upgrade setuptools to >=75.0 after NumPy installation to maintain security and modern standards for the final image.
6. - Standardize Python 3.10 and Alpine 3.22 as the base foundation.
7. - Maintain Cython 0.29.37 for C-extension stability.